### PR TITLE
fix: Check existents of angular.json in right path

### DIFF
--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -36,7 +36,7 @@ export const executeAngularCli = async (command: ISupportedAngularCommand, ...op
 export const isAngularProject = (absolutePath?: string): boolean => {
    absolutePath = absolutePath || process.cwd();
    const parentPath = path.join(absolutePath, '../');
-   if (fs.existsSync('angular.json')) {
+   if (fs.existsSync(path.join(absolutePath, 'angular.json'))) {
       return true;
    } else if (parentPath === absolutePath) {
       return false;


### PR DESCRIPTION
I try to establish a angular monorepo for libraries and multiple apps. Currently odin doesn't find the angular.json file in the top directory of the repo. This fix solves that problem.