### PR TITLE
fix: missing font family for soho example

### DIFF
--- a/m3-odin/boilerplate/infor-m3-odin-sample-soho/index.html
+++ b/m3-odin/boilerplate/infor-m3-odin-sample-soho/index.html
@@ -8,6 +8,7 @@
    <link href="assets/favicon.ico" type="image/x-icon" rel="icon">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <link rel="stylesheet" id="stylesheet" href="assets/ids-enterprise/css/light-theme.css" type="text/css">
+   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600&display=swap">
 </head>
 
 <body>


### PR DESCRIPTION
When creating a new application with odin cli, using soho not material, the index.html file did not have a link to the source-sans-pro font.