### PR TITLE
soho-boilerplate: angular.json build only glob nessecary files

### DIFF
--- a/cli/boilerplate/angular-soho/angular.json
+++ b/cli/boilerplate/angular-soho/angular.json
@@ -6,9 +6,10 @@
                "options": {
                   "assets": [
                      {
-                        "glob": "**/*",
+                        "glob": "**/*.css",
                         "input": "./node_modules/ids-enterprise/dist/css",
-                        "output": "/assets/ids-enterprise/css"
+                        "output": "/assets/ids-enterprise/css",
+                        "ignore": ["**/*.min.css"]
                      },
                      {
                         "glob": "**/*",


### PR DESCRIPTION
This issue came up because M3 "usually" only allows up to 10MB files to be installed via the "Personlization Manager".
It does also bring a performance boost on smaller devices since not as many CSS files are transfered.