### PR TITLE
Use minified enterprise(-ng) versions in angular-soho app.

### DIFF
--- a/cli/boilerplate/angular-soho/angular.json
+++ b/cli/boilerplate/angular-soho/angular.json
@@ -6,12 +6,12 @@
                "options": {
                   "assets": [
                      {
-                        "glob": "**/*",
+                        "glob": "**/*.min.css",
                         "input": "./node_modules/ids-enterprise/dist/css",
                         "output": "/assets/ids-enterprise/css"
                      },
                      {
-                        "glob": "**/*",
+                        "glob": "**/*.min.js",
                         "input": "./node_modules/ids-enterprise/dist/js/cultures",
                         "output": "/assets/ids-enterprise/js/cultures"
                      }

--- a/cli/boilerplate/angular-soho/src/index.html
+++ b/cli/boilerplate/angular-soho/src/index.html
@@ -9,7 +9,11 @@
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <link rel="icon" type="image/x-icon" href="favicon.ico">
    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro" rel="stylesheet">
-   <link rel="stylesheet" id="stylesheet" href="assets/ids-enterprise/css/theme-new-light.css" type="text/css">
+   <link rel="stylesheet" id="stylesheet" href="assets/ids-enterprise/css/theme-new-light.min.css" type="text/css">
+   <script>
+      // https://github.com/infor-design/enterprise/tree/main/src/components/locale#code-example---using-minified-files
+      window["SohoConfig"] = { minifyCultures: true };
+   </script>
 </head>
 
 <body>


### PR DESCRIPTION
This PR is a replacement of #114 to use minified version of themes and cultures in applications generated with `odin new`. See also the issue #118. Thank you to @dohjon for the example!

Currently there is no option to include `theme-new*` files only.