### PR TITLE
Use most of Angular strictTemplate checks.

### DIFF
--- a/m3-odin/tsconfig.json
+++ b/m3-odin/tsconfig.json
@@ -28,5 +28,9 @@
    },
    "exclude": [
       "boilerplate"
-   ]
+   ],
+   "angularCompilerOptions": {
+      "strictTemplates": true,
+      "strictInputTypes": false
+   },
 }


### PR DESCRIPTION
I prefer the strict checkings from Angular, but here is an exception necessary, because of soho-datagrid. Angular doesn't detect the soho-datagrid directive.