### PR TITLE
Enable tests for all angular projects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,4 +142,4 @@ jobs:
         run: |
           cd ./m3-odin
           npm ci
-          npm run ng -- test @infor-up/m3-odin --code-coverage --browsers=ChromeHeadlessCI
+          npm run ng -- test --code-coverage --browsers=ChromeHeadlessCI

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,8 +138,18 @@ jobs:
         with:
           node-version: '16'
 
-      - name: run tests
+      - name: Install packages
         run: |
           cd ./m3-odin
           npm ci
+
+      - name: Build libraries
+        run: |
+          cd ./m3-odin
+          npm run ng -- build @infor-up/m3-odin
+          npm run ng -- build @infor-up/m3-odin-angular
+
+      - name: Run tests
+        run: |
+          cd ./m3-odin
           npm run ng -- test --code-coverage --browsers=ChromeHeadlessCI

--- a/m3-odin/angular.json
+++ b/m3-odin/angular.json
@@ -106,7 +106,7 @@
                   "karmaConfig": "src/karma.conf.js",
                   "styles": [
                      {
-                        "input": "styles.css",
+                        "input": "src/styles.css",
                         "inject": true
                      }
                   ],

--- a/m3-odin/projects/infor-up/m3-odin-angular/karma.conf.js
+++ b/m3-odin/projects/infor-up/m3-odin-angular/karma.conf.js
@@ -17,16 +17,33 @@ module.exports = function (config) {
       },
       coverageReporter: {
          dir: require('path').join(__dirname, '../../../coverage/infor-up/m3-odin-angular'),
-         reports: ['html', 'lcovonly', 'text-summary'],
-         fixWebpackSourcePaths: true
+         reporters: [
+            { type: 'html' },
+            { type: 'text-summary' }
+         ],
+         fixWebpackSourcePaths: true,
+         check: {
+            global: {
+              statements: 24,
+              branches: 80,
+              functions: 8,
+              lines: 25
+            }
+         },    
       },
-      reporters: ['progress', 'kjhtml', 'coverage'],
+      reporters: ['progress', 'kjhtml'],
       port: 9876,
       colors: true,
       logLevel: config.LOG_INFO,
       autoWatch: true,
-      browsers: ['ChromeHeadless'],
-      singleRun: false,
-      restartOnFileChange: true
+      browsers: ['Chrome'],
+      singleRun: true,
+      restartOnFileChange: true,
+      customLaunchers: {
+         ChromeHeadlessCI: {
+           base: 'ChromeHeadless',
+           flags: ['--no-sandbox'],
+         },
+       },   
    });
 };

--- a/m3-odin/src/karma.conf.js
+++ b/m3-odin/src/karma.conf.js
@@ -34,7 +34,7 @@ module.exports = function (config) {
               statements: 10,
               branches: 1,
               functions: 3,
-              lines: 11
+              lines: 10
             }
          },
       },

--- a/m3-odin/src/karma.conf.js
+++ b/m3-odin/src/karma.conf.js
@@ -9,7 +9,7 @@ module.exports = function (config) {
          require('karma-jasmine'),
          require('karma-chrome-launcher'),
          require('karma-jasmine-html-reporter'),
-         require('karma-coverage-istanbul-reporter'),
+         require('karma-coverage'),
          require('@angular-devkit/build-angular/plugins/karma')
       ],
       files: [
@@ -22,10 +22,21 @@ module.exports = function (config) {
       client: {
          clearContext: false // leave Jasmine Spec Runner output visible in browser
       },
-      coverageIstanbulReporter: {
-         dir: require('path').join(__dirname, 'coverage'),
-         reports: ['html', 'lcovonly'],
-         fixWebpackSourcePaths: true
+      coverageReporter: {
+         dir: require('path').join(__dirname, '../coverage/m3-odin-samples'),
+         reporters: [
+            { type: 'html' },
+            { type: 'text-summary' }
+         ],
+         fixWebpackSourcePaths: true,
+         check: {
+            global: {
+              statements: 10,
+              branches: 1,
+              functions: 3,
+              lines: 11
+            }
+         },
       },
       reporters: ['progress', 'kjhtml'],
       port: 9876,
@@ -33,6 +44,12 @@ module.exports = function (config) {
       logLevel: config.LOG_INFO,
       autoWatch: true,
       browsers: ['Chrome'],
-      singleRun: false
+      singleRun: true,
+      customLaunchers: {
+         ChromeHeadlessCI: {
+           base: 'ChromeHeadless',
+           flags: ['--no-sandbox'],
+         },
+       },   
    });
 };

--- a/m3-odin/src/test.ts
+++ b/m3-odin/src/test.ts
@@ -1,8 +1,8 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
+import 'zone.js/testing';
 
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
-import 'zone.js/testing';
 
 declare const require: any;
 


### PR DESCRIPTION
This PR is the next step to increase code quality by running unit tests for all Angular projects. The code coverage for `m3-odin-sample` and `@infor-up/m3-odin-angular` isn't good currently, but we can increase it step by step afterwards.