### PR TITLE
Added EUID (InforOS UserID) to IUserContext

### DIFF
--- a/m3-odin/projects/infor-up/m3-odin/src/lib/m3/types.ts
+++ b/m3-odin/projects/infor-up/m3-odin/src/lib/m3/types.ts
@@ -190,6 +190,11 @@ export interface IUserContext extends IErrorState {
    FADT?: string;
 
    /**
+    * Contains the universal UserID in UUID format
+    */
+   EUID?: string;
+
+   /**
     * First active date in the M3 calendar.
     */
    firstActiveDate?: Date;


### PR DESCRIPTION
M3 Cloud contains EUID which is the global User ID between Infor applications. 
This is already returned in the UserContext, but is not defined in the IUSerContext interface. 