### PR TITLE
Added enable-automation to puppeteer.launch to enable credentials suggestion dropdown

### DIFF
--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -100,6 +100,7 @@ export async function login(options: LoginOptions) {
          width: WINDOW_WIDTH,
          height: WINDOW_HEIGHT,
       },
+      ignoreDefaultArgs: ['--enable-automation']
    });
    const [page] = await browser.pages();
    console.log('Waiting for ION API Token');


### PR DESCRIPTION
Puppeteer doesn't allow the browser to save credentials, by adding enable-automation it should not run in "test/incognito" mode, which also should enable automatic username & password suggestions

I do not have the knowledge/possibility to test this change, I hope that someone in here could run and validate the change. 