### PR TITLE
✨ feat(getMetadata): Return only one field

### DIFF
--- a/m3-odin/projects/infor-up/m3-odin/src/lib/mi/runtime.ts
+++ b/m3-odin/projects/infor-up/m3-odin/src/lib/mi/runtime.ts
@@ -717,6 +717,14 @@ export class MIServiceCore extends CoreBase implements IMIService {
             }
             return metadataMap;
          }
+         else if (input && input.Field) {
+            var metadataMap = {};
+            var entry = input.Field;
+            var name = entry['@name'];
+            var metaDataInfo = new MIMetadataInfo(name, entry['@length'], entry['@type'], entry['@description']);
+            metadataMap[name] = metaDataInfo;
+            return metadataMap;
+         }
       } catch (e) {
          // TODO Support some kind of logger injection for logging.
       }


### PR DESCRIPTION
Added fix to metadataMap. This addition also returns metadata if only one field was requested. Up until now no metadata are returned, because the return is not an array, but an object. This adds the ability to parse an object too.

Bug: [#187](https://github.com/infor-cloud/m3-h5-sdk/issues/187#issue-2088065655)