### PR TITLE
Added support to override the user that executes the API towards M3

### DIFF
--- a/m3-odin/projects/infor-up/m3-odin/src/lib/mi/runtime.ts
+++ b/m3-odin/projects/infor-up/m3-odin/src/lib/mi/runtime.ts
@@ -512,6 +512,11 @@ export class MIServiceCore extends CoreBase implements IMIService {
          }
       }
 
+      const m3User = request.m3User;
+      if (m3User) {
+         url += ';m3User=' + m3User;
+      }
+
       // Add optional parameters
       if (returnCols) {
          url += ';returncols=' + returnCols;

--- a/m3-odin/projects/infor-up/m3-odin/src/lib/mi/types.ts
+++ b/m3-odin/projects/infor-up/m3-odin/src/lib/mi/types.ts
@@ -86,6 +86,11 @@ export interface IMIOptions {
     * The default value is true.
     */
    enableCsrf?: boolean;
+
+   /**
+    * Overrides the user that will execute the API call towards M3
+    */
+   m3User?: string;
 }
 
 /**


### PR DESCRIPTION
The API url parameter "m3User" allows you to change the user that executes the API call.
This is overall a bad implementation in M3, but the attribute exist and therefore it should also be implemented in the Odin library.

This is used mainly when running service accounts, but need to mark the transaction towards specific users.