### PR TITLE
Removed debug logging

### DIFF
--- a/m3-odin/projects/infor-up/m3-odin/src/lib/mi/runtime.ts
+++ b/m3-odin/projects/infor-up/m3-odin/src/lib/mi/runtime.ts
@@ -462,7 +462,6 @@ export class MIServiceCore extends CoreBase implements IMIService {
     * @hidden
     */
    public createUrl(baseUrl: string, request: IMIRequest): string {
-      console.log('SVEN', baseUrl, request);
       let url = baseUrl + '/' + request.program + '/' + request.transaction;
       let maxRecords = 100;
       let excludeEmpty = 'true';
@@ -491,7 +490,6 @@ export class MIServiceCore extends CoreBase implements IMIService {
       let company = request.company;
       let division = request.division;
 
-      console.log('Hallo', this.currentCompany);
       if (!company && this.currentCompany) {
          // If no values are set in the request and a user context exist the values from the user context are used.
          company = this.currentCompany;


### PR DESCRIPTION
For some reason, there has been 2 log messages that someone used for debugging. These are filling up the console quickly and are uneccesary.