### PR TITLE
CLI: login-cloud command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 7.2.0
+
+- Added new `login-cloud` command.
+- `odin new` command has been modified to accept a value for portal url.
+
+## Notes
+
+- To use the new command in an existing project, you need to update your `odin.json` file to include the following properties (update with your own urls):
+  ```json
+  {
+    "m3Url": "https://m3xyz.m3.xyz.inforcloudsuite.com",
+    "portalUrl": "https://mingle-xyz-portal.xyz.inforcloudsuite.com"
+  }
+  ```
+
 # 7.1.1
 
 - Export of MIUtil and Bookmark classes.
@@ -10,7 +25,7 @@
 
 ## Known Issues
 
-- 
+-
 
 # 7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## Notes
 
-- To use the new command in an existing project, you need to update your `odin.json` file to include the following properties (update with your own urls):
+- To use the new `login-cloud` command in an existing project, you need to update your `odin.json` file to include the following properties (update with your own urls):
   ```json
   {
     "m3Url": "https://m3xyz.m3.xyz.inforcloudsuite.com",

--- a/cli/boilerplate/angular-soho/package.json
+++ b/cli/boilerplate/angular-soho/package.json
@@ -1,7 +1,7 @@
 {
    "dependencies": {
-      "@infor-up/m3-odin": "7.1.1",
-      "@infor-up/m3-odin-angular": "7.1.1",
+      "@infor-up/m3-odin": "7.2.0",
+      "@infor-up/m3-odin-angular": "7.2.0",
       "ids-enterprise-ng": "18.2.4"
    },
    "devDependencies": {}

--- a/cli/boilerplate/angular/package.json
+++ b/cli/boilerplate/angular/package.json
@@ -1,7 +1,7 @@
 {
    "dependencies": {
-      "@infor-up/m3-odin": "7.1.1",
-      "@infor-up/m3-odin-angular": "7.1.1"
+      "@infor-up/m3-odin": "7.2.0",
+      "@infor-up/m3-odin-angular": "7.2.0"
    },
    "devDependencies": {}
 }

--- a/cli/boilerplate/basic/odin.json
+++ b/cli/boilerplate/basic/odin.json
@@ -1,5 +1,7 @@
 {
    "projectName": "ODIN_PROJECT_NAME",
+   "m3Url": "ODIN_M3_URL",
+   "portalUrl": "ODIN_PORTAL_URL",
    "proxy": {
       "/m3api-rest": {
          "target": "ODIN_PROXY_TARGET",

--- a/cli/boilerplate/basic/package.json
+++ b/cli/boilerplate/basic/package.json
@@ -11,8 +11,8 @@
    "author": "",
    "license": "UNLICENSED",
    "devDependencies": {
-      "@infor-up/m3-odin-cli": "7.1.1",
-      "@infor-up/m3-odin": "7.1.1",
+      "@infor-up/m3-odin-cli": "7.2.0",
+      "@infor-up/m3-odin": "7.2.0",
       "rxjs": "^7.8.0",
       "typescript": "~5.2.2"
    }

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "@infor-up/m3-odin-cli",
-   "version": "7.1.1",
+   "version": "7.2.0",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "@infor-up/m3-odin-cli",
-         "version": "7.1.1",
+         "version": "7.2.0",
          "license": "Apache-2.0",
          "dependencies": {
             "@angular/cli": "^18.2.4",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -2028,17 +2028,26 @@
          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
       },
       "node_modules/chokidar": {
-         "version": "4.0.1",
-         "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
-         "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+         "version": "3.6.0",
+         "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+         "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
          "dependencies": {
-            "readdirp": "^4.0.1"
+            "anymatch": "~3.1.2",
+            "braces": "~3.0.2",
+            "glob-parent": "~5.1.2",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.6.0"
          },
          "engines": {
-            "node": ">= 14.16.0"
+            "node": ">= 8.10.0"
          },
          "funding": {
             "url": "https://paulmillr.com/funding/"
+         },
+         "optionalDependencies": {
+            "fsevents": "~2.3.2"
          }
       },
       "node_modules/chownr": {
@@ -5624,15 +5633,25 @@
          }
       },
       "node_modules/readdirp": {
-         "version": "4.0.2",
-         "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
-         "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+         "version": "3.6.0",
+         "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+         "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+         "dependencies": {
+            "picomatch": "^2.2.1"
+         },
          "engines": {
-            "node": ">= 14.16.0"
+            "node": ">=8.10.0"
+         }
+      },
+      "node_modules/readdirp/node_modules/picomatch": {
+         "version": "2.3.1",
+         "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+         "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+         "engines": {
+            "node": ">=8.6"
          },
          "funding": {
-            "type": "individual",
-            "url": "https://paulmillr.com/funding/"
+            "url": "https://github.com/sponsors/jonschlinkert"
          }
       },
       "node_modules/relateurl": {
@@ -5826,6 +5845,32 @@
             "sass-embedded": {
                "optional": true
             }
+         }
+      },
+      "node_modules/sass/node_modules/chokidar": {
+         "version": "4.0.3",
+         "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+         "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+         "dependencies": {
+            "readdirp": "^4.0.1"
+         },
+         "engines": {
+            "node": ">= 14.16.0"
+         },
+         "funding": {
+            "url": "https://paulmillr.com/funding/"
+         }
+      },
+      "node_modules/sass/node_modules/readdirp": {
+         "version": "4.1.2",
+         "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+         "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+         "engines": {
+            "node": ">= 14.18.0"
+         },
+         "funding": {
+            "type": "individual",
+            "url": "https://paulmillr.com/funding/"
          }
       },
       "node_modules/schema-utils": {
@@ -7043,51 +7088,6 @@
             "ajv": {
                "optional": true
             }
-         }
-      },
-      "node_modules/webpack-dev-server/node_modules/chokidar": {
-         "version": "3.6.0",
-         "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-         "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-         "dependencies": {
-            "anymatch": "~3.1.2",
-            "braces": "~3.0.2",
-            "glob-parent": "~5.1.2",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.6.0"
-         },
-         "engines": {
-            "node": ">= 8.10.0"
-         },
-         "funding": {
-            "url": "https://paulmillr.com/funding/"
-         },
-         "optionalDependencies": {
-            "fsevents": "~2.3.2"
-         }
-      },
-      "node_modules/webpack-dev-server/node_modules/picomatch": {
-         "version": "2.3.1",
-         "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-         "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-         "engines": {
-            "node": ">=8.6"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/jonschlinkert"
-         }
-      },
-      "node_modules/webpack-dev-server/node_modules/readdirp": {
-         "version": "3.6.0",
-         "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-         "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-         "dependencies": {
-            "picomatch": "^2.2.1"
-         },
-         "engines": {
-            "node": ">=8.10.0"
          }
       },
       "node_modules/webpack-dev-server/node_modules/schema-utils": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -10,8 +10,8 @@
       "clean": "git clean -f -d -X dist"
    },
    "author": {
-      "name": "Gunilla Andersson",
-      "email": "gunilla.andersson@infor.com"
+      "name": "William Hernebrink",
+      "email": "william.hernebrink@infor.com"
    },
    "license": "Apache-2.0",
    "repository": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@infor-up/m3-odin-cli",
-   "version": "7.1.1",
+   "version": "7.2.0",
    "description": "Odin CLI",
    "scripts": {
       "build": "tsc",

--- a/cli/package.json
+++ b/cli/package.json
@@ -10,8 +10,8 @@
       "clean": "git clean -f -d -X dist"
    },
    "author": {
-      "name": "Fredrik Eriksson",
-      "email": "fredrik.eriksson@infor.com"
+      "name": "Gunilla Andersson",
+      "email": "gunilla.andersson@infor.com"
    },
    "license": "Apache-2.0",
    "repository": {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import type { ConfirmQuestion, InputQuestion, ListQuestion } from 'inquirer';
 import inquirer from 'inquirer';
 import path from 'path';
 import url from "url";
-import { buildProject, INewProjectOptions, IServeOptions, login, newProject, serveProject, setConfiguration } from './commands/index.js';
+import { buildProject, INewProjectOptions, IServeOptions, login, loginCloud, newProject, serveProject, setConfiguration } from './commands/index.js';
 import { isValidProxyUrl } from './utils.js';
 
 // For __dirname in es module: https://blog.logrocket.com/alternatives-dirname-node-js-es-modules/
@@ -272,6 +272,19 @@ program
             m3Url: options.m3,
             updateConfig: options.updateConfig,
          });
+      } catch (error) {
+         console.error(error);
+         exit('Login command failed');
+      }
+   });
+
+program
+   .command('login-cloud <ionApiConfigPath>')
+   // .option('-c, --update-config', 'Update odin.json configuration')
+   .description('Multi-Tenant login')
+   .action(async (ionApiConfig: string, options) => {
+      try {
+         await loginCloud({ ionApiConfig });
       } catch (error) {
          console.error(error);
          exit('Login command failed');

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -56,52 +56,194 @@ program
    .name('odin')
    .description('Tool to set up and manage a web application with Odin.');
 
+/**
+ * Take raw commander inputs, validate CLI‐only bits
+ * and return a partial “overrides” object.
+ */
+function buildCliOptions(projectName: string, opts: any) {
+   const cli: any = {};
+
+   if (projectName) {
+      cli.name = projectName;
+   }
+
+   // style flag: soho => 'soho', explicitly --no-soho => 'none'
+   if (opts.soho !== undefined) {
+      cli.style = opts.soho ? 'soho' : 'none';
+   }
+
+   if (opts.angular !== undefined) {
+      cli.angular = opts.angular;
+   }
+
+   if (opts.install !== undefined) {
+      cli.install = opts.install;
+   }
+
+   if (opts.skipGit !== undefined) {
+      cli.git = !opts.skipGit;
+   }
+
+   if (opts.proxy) {
+      if (!isValidProxyUrl(opts.proxy)) {
+         exit(
+            `Proxy url '${opts.proxy}' is invalid.`
+            + ` It should be protocol://hostname:port`
+         );
+      }
+      cli.proxy = { target: opts.proxy };
+   }
+
+   if (opts.portal) {
+      if (!isValidProxyUrl(opts.portal)) {
+         exit(
+            `Portal url '${opts.portal}' is invalid.`
+            + ` It should be protocol://hostname`
+         );
+      }
+      cli.portal = opts.portal;
+   }
+
+   return cli;
+}
+
+/**
+ * Given a partial overrides object, prompt only
+ * for the values that are still undefined.
+ */
+async function promptMissingOptions(overrides: any) {
+   const questions = [];
+
+   if (!overrides.name) {
+      questions.push({
+         type: 'input',
+         name: 'name',
+         message: 'What is the name of the project?',
+         validate: (input: string) => {
+            if (!/^[a-zA-Z0-9-]+$/.test(input)) {
+               return 'Only letters, numbers and dashes are allowed.';
+            }
+            if (fs.existsSync(input)) {
+               return 'That directory already exists.';
+            }
+            return true;
+         }
+      });
+   }
+
+   if (overrides.style === undefined) {
+      questions.push({
+         type: 'list',
+         name: 'style',
+         message: 'Which style library do you want to use?',
+         choices: [
+            { name: 'SoHo (Infor Design System)', value: 'soho' },
+            { name: 'None', value: 'none' }
+         ],
+         default: 'soho'
+      });
+   }
+
+   if (overrides.angular === undefined) {
+      questions.push({
+         type: 'confirm',
+         name: 'angular',
+         message: 'Use Angular CLI project structure?',
+         default: true
+      });
+   }
+
+   if (!overrides.proxy) {
+      questions.push({
+         type: 'input',
+         name: 'proxy',
+         message: 'What is the URL of your M3 environment?',
+         default: 'https://m3prdxyz.m3.xyz.inforcloudsuite.com',
+         validate: (url: string) =>
+            isValidProxyUrl(url)
+               ? true
+               : 'Must be valid URL like: protocol://hostname:port'
+      });
+   }
+
+   if (!overrides.portal) {
+      questions.push({
+         type: 'input',
+         name: 'portal',
+         message: 'What is the URL of your Portal environment?',
+         default: 'https://mingle-xyz-portal.xyz.inforcloudsuite.com',
+         validate: (url: string) =>
+            isValidProxyUrl(url)
+               ? true
+               : 'Must be valid URL like: protocol://hostname'
+      });
+   }
+
+   if (overrides.git === undefined) {
+      questions.push({
+         type: 'confirm',
+         name: 'git',
+         message: 'Initialize a Git repository?',
+         default: true
+      });
+   }
+
+   if (overrides.install === undefined) {
+      questions.push({
+         type: 'confirm',
+         name: 'install',
+         message: 'Install NPM dependencies? (this may take a while)',
+         default: false
+      });
+   }
+
+   const answers = questions.length
+      ? await inquirer.prompt(questions)
+      : {};
+
+   // Merge CLI overrides + prompted answers
+   return {
+      name: overrides.name || answers.name,
+      style: overrides.style || answers.style,
+      angular:
+         overrides.angular !== undefined
+            ? overrides.angular
+            : answers.angular,
+      proxy:
+         overrides.proxy ||
+         { target: answers.proxy },
+      portalUrl: overrides.portal !== undefined ? overrides.portal : answers.portal,
+      git:
+         overrides.git !== undefined
+            ? overrides.git
+            : answers.git,
+      install:
+         overrides.install !== undefined
+            ? overrides.install
+            : answers.install,
+      m3Url: overrides.m3Url || answers.m3Url,
+      tenant: overrides.tenant || answers.tenant
+   };
+}
+
+// ─── CLI SETUP ────────────────────────────────────────────────────────────────
 program
    .command('new [projectName]')
    .description('Create a new project')
-   .option('--proxy [url]', 'URL to MI REST Service, e.g "https://my.m3.environment.com:54008"')
-   .option('-s, --soho', 'Set up as a Soho-styled project')
-   .option('-a, --angular', 'Set up as an Angular CLI project')
-   .option('-i, --install', 'Install NPM dependencies')
-   .option('--skip-git', 'Skip initialization of a git repository')
-   .action(async (projectName, options) => {
-      if (!projectName) {
-         return await inquireNewProject();
+   .option('-s, --soho', 'Set up as a Soho-styled project', undefined)
+   .option('-a, --angular', 'Set up as an Angular CLI project', undefined)
+   .option('-i, --install', 'Install NPM dependencies', undefined)
+   .option('--skip-git', 'Skip initialization of a git repo', undefined)
+   .option('-p, --proxy <url>', 'URL for M3 environment')
+   .option('-po, --portal <url>', 'URL for Portal environment')
+   .action(async (projectName, opts) => {
+      try {
+         const cliOverrides = buildCliOptions(projectName, opts);
+         const fullOpts = await promptMissingOptions(cliOverrides);
+         await wrapNew(fullOpts);
+      } catch (err: any) {
+         exit(err.message);
       }
-      const newOptions: INewProjectOptions = {
-         name: projectName,
-         style: 'none',
-      };
-      if (options.proxy) {
-         if (!isValidProxyUrl(options.proxy)) {
-            exit(`Proxy url '${options.proxy}' is invalid. It should be of the format: protocol://hostname:port`);
-         }
-         newOptions.proxy = {
-            target: options.proxy,
-         };
-      }
-
-      if (options.soho) {
-         newOptions.style = 'soho';
-      } else {
-         newOptions.style = 'none';
-      }
-
-      if (options.skipGit) {
-         newOptions.git = false;
-      } else {
-         newOptions.git = true;
-      }
-
-      if (options.angular) {
-         newOptions.angular = true;
-      }
-
-      if (options.install) {
-         newOptions.install = true;
-      }
-
-      await wrapNew(newOptions);
    });
 
 program
@@ -120,7 +262,6 @@ program
 
 program
    .command('login <ionApiConfigPath>')
-   .alias('experimental-login')
    .option('--m3 <m3Url>', 'URL to M3')
    .option('-c, --update-config', 'Update odin.json configuration')
    .description('Multi-Tenant login')

--- a/cli/src/commands/index.ts
+++ b/cli/src/commands/index.ts
@@ -1,5 +1,6 @@
 export { buildProject } from './build.js';
 export { login } from './login.js';
+export { loginCloud } from './login/login-cloud.js';
 export { INewProjectOptions, newProject } from './new.js';
 export { IServeOptions, serveProject } from './serve.js';
 export { setConfiguration } from './set.js';

--- a/cli/src/commands/login/login-cloud.ts
+++ b/cli/src/commands/login/login-cloud.ts
@@ -1,0 +1,48 @@
+
+import puppeteer from 'puppeteer';
+import { LoginOptions } from './models.js';
+import { readIonApiConfig, waitForMneCookies, writeCookiesToFile } from './utils.js';
+import { readConfig } from '../../utils.js';
+
+const WINDOW_WIDTH = 500;
+const WINDOW_HEIGHT = 600;
+
+export async function loginCloud({ ionApiConfig }: LoginOptions) {
+   const { tenant } = readIonApiConfig(ionApiConfig);
+   const odinConfig = readConfig();
+
+   const browser = await puppeteer.launch({
+      headless: false,
+      args: [
+         `--app=${odinConfig.portalUrl}/${tenant}`,
+         `--window-size=${WINDOW_WIDTH},${WINDOW_HEIGHT}`,
+      ],
+      defaultViewport: {
+         width: WINDOW_WIDTH,
+         height: WINDOW_HEIGHT,
+      },
+   });
+   const [page] = await browser.pages();
+   await page.waitForSelector("portal-root", { visible: true, timeout: 0 });
+
+   await page.goto(`${odinConfig.m3Url}/mne`);
+   const cookies = await waitForMneCookies(page);
+   writeCookiesToFile(cookies);
+   console.log("Got M3 session cookie", cookies);
+
+   // console.log('Waiting for ION API Token');
+   // const token = await waitForAccessToken(page, config);
+   // writeTokenToFile(token);
+   // console.log('Got ION API token');
+
+   // if (options.updateConfig) {
+   //    console.log('Updating odin.json');
+   //    updateOdinConfig(config, options.m3Url);
+   //    console.log('odin.json has been updated');
+   // }
+
+   await browser.close();
+
+   console.log('Login successful! You can now run "odin serve --multi-tenant"');
+}
+

--- a/cli/src/commands/login/login-cloud.ts
+++ b/cli/src/commands/login/login-cloud.ts
@@ -28,12 +28,7 @@ export async function loginCloud({ ionApiConfig }: LoginOptions) {
    await page.goto(`${odinConfig.m3Url}/mne`);
    const cookies = await waitForMneCookies(page);
    writeCookiesToFile(cookies);
-   console.log("Got M3 session cookie", cookies);
-
-   // console.log('Waiting for ION API Token');
-   // const token = await waitForAccessToken(page, config);
-   // writeTokenToFile(token);
-   // console.log('Got ION API token');
+   console.log("Got M3 session cookie");
 
    // if (options.updateConfig) {
    //    console.log('Updating odin.json');

--- a/cli/src/commands/login/models.ts
+++ b/cli/src/commands/login/models.ts
@@ -1,0 +1,88 @@
+import { urlJoin } from "./utils.js";
+import puppeteer from 'puppeteer';
+
+export interface RawIonApiConfig {
+  /**
+   * Tenant
+   */
+  ti: string;
+  /**
+   * Application name
+   */
+  cn: string;
+  dt: string;
+  /**
+   * client_id
+   */
+  ci: string;
+  /**
+   * client_secret
+   */
+  cs: string;
+  /**
+   * ION API host
+   */
+  iu: string;
+  /**
+   * Auth provider URL
+   */
+  pu: string;
+  /**
+   * Authorization path
+   */
+  oa: string;
+  ot: string;
+  or: string;
+  /**
+   * redirect_uri
+   */
+  ru: string;
+  ev: string;
+  v: string;
+}
+
+export class IonApiConfig {
+  constructor(private data: RawIonApiConfig) { }
+
+  get tenant() {
+    return this.data.ti;
+  }
+
+  get clientId() {
+    return this.data.ci;
+  }
+
+  get redirectUri() {
+    return this.data.ru;
+  }
+
+  get ionApiUrl() {
+    return urlJoin(this.data.iu, this.tenant);
+  }
+
+  get authUrl() {
+    const url = new URL(urlJoin(this.data.pu, this.data.oa));
+    url.searchParams.set('client_id', this.clientId);
+    url.searchParams.set('redirect_uri', this.redirectUri);
+    url.searchParams.set('response_type', 'token');
+    return url.toString();
+  }
+}
+
+export interface LoginOptions {
+  ionApiConfig: string;
+  m3Url?: string;
+  updateConfig?: boolean;
+}
+
+
+export interface Token {
+  access_token: string;
+  token_type: string;
+  expires_in: string;
+}
+
+/**
+ * NOTE: This used to be puppeteer.Cookie
+ */
+export type Cookie = puppeteer.Protocol.Network.Cookie

--- a/cli/src/commands/login/utils.ts
+++ b/cli/src/commands/login/utils.ts
@@ -1,0 +1,97 @@
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import puppeteer from 'puppeteer';
+import { ProxyConfigMap } from 'webpack-dev-server';
+import { Cookie, IonApiConfig, RawIonApiConfig, Token } from './models.js';
+import { readConfig, writeConfig } from '../../utils.js';
+
+export function urlJoin(...segments: string[]): string {
+  return segments.map(segment => segment.replace(/(^\/|\/$)/g, '')).join('/');
+}
+
+export function readIonApiConfig(configPath: string): IonApiConfig {
+  const data: RawIonApiConfig = fs.readJSONSync(configPath);
+  return new IonApiConfig(data);
+}
+
+export function updateOdinConfig(ionApiConfig: IonApiConfig, m3Url?: string) {
+  const odinConfig = readConfig();
+  const ionTarget = setTarget('/ODIN_DEV_TENANT', ionApiConfig.ionApiUrl);
+  ionTarget.pathRewrite = { '^/ODIN_DEV_TENANT': '' };
+  if (m3Url) {
+    setTarget('/m3api-rest', m3Url);
+    setTarget('/mne', m3Url);
+    setTarget('/ca', m3Url);
+  } else {
+    setTarget('/m3api-rest', ionApiConfig.ionApiUrl);
+  }
+  writeConfig(odinConfig);
+
+  function setTarget(proxyPath: string, target: string) {
+    console.log(`Update target ${proxyPath} -> ${target}`);
+    const config = getPathConfig(proxyPath);
+    config.target = target;
+    return config;
+  }
+
+  function getPathConfig(proxyPath: string) {
+    if (odinConfig.proxy && !Array.isArray(odinConfig.proxy)) {
+      const pathConfig = (odinConfig.proxy as ProxyConfigMap)[proxyPath];
+      if (typeof pathConfig !== 'string') {
+        return pathConfig;
+      }
+    }
+    throw new Error(`Could not get proxy config for path ${proxyPath}`);
+  }
+}
+
+export function writeTokenToFile(token: Token) {
+  // File paths & content should match mtauth.ts
+  const filePath = path.resolve(os.tmpdir(), 'authorizationheader.json');
+  const content = {
+    authorizationHeader: `${token.token_type} ${token.access_token}`,
+    // expirationTimestamp: token.expires_in,
+  };
+  fs.writeJsonSync(filePath, content);
+}
+
+export function writeCookiesToFile(cookies: Cookie[]) {
+  // File paths & content should match mtauth.ts
+  const filePath = path.resolve(os.tmpdir(), 'cookieheader.json');
+  const content = cookies.map(({ name, value }) => `${name}=${value};`).join(' ');
+  fs.writeFileSync(filePath, content);
+}
+
+
+export async function waitForMneCookies(page: puppeteer.Page): Promise<Cookie[]> {
+  return new Promise<Cookie[]>((resolvePromise, rejectPromise) => {
+    const intervalId = setInterval(async () => {
+      try {
+        const cookies = await getAllCookies(page);
+        const sessionCookie = cookies.find(mneSessionCookie);
+        if (sessionCookie) {
+          clearInterval(intervalId);
+          resolvePromise(cookies);
+        }
+      } catch (error) {
+        clearInterval(intervalId);
+        rejectPromise(error);
+      }
+    }, 1000);
+  });
+
+  // TODO - type this: puppeteer.Page
+  async function getAllCookies(_page: any): Promise<Cookie[]> {
+
+    const getAllCookiesResponse = await _page
+      ._client()
+      .send("Network.getAllCookies");
+    return getAllCookiesResponse.cookies;
+
+  }
+
+  function mneSessionCookie(cookie: Cookie) {
+    return cookie.path === '/mne' && cookie.name === 'JSESSIONID';
+  }
+}

--- a/cli/src/commands/new.ts
+++ b/cli/src/commands/new.ts
@@ -17,6 +17,7 @@ export interface INewProjectOptions {
    angular?: boolean;
    install?: boolean;
    git?: boolean;
+   portalUrl?: string;
 }
 
 
@@ -125,6 +126,15 @@ const addOdinConfig = (projectRoot: string, options: INewProjectOptions) => {
    } else {
       console.warn('Warning: Proxy is not configured. You will need to configure it in \'odin.json\', or with the \'odin set\' command');
    }
+
+   if (options.proxy?.target) {
+      config.m3Url = options.proxy.target;
+   }
+
+   if (options.portalUrl) {
+      config.portalUrl = options.portalUrl;
+   }
+
    configureName(options.name, config);
    writeConfig(config, projectRoot);
 };

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -11,13 +11,26 @@ type ISupportedAngularCommand = 'new' | 'serve' | 'build';
 
 export interface IOdinConfiguration extends Configuration {
    projectName?: string;
+   m3Url?: string;
+   portalUrl?: string;
 }
 
 export const removeSurroundingSlash = (text: string): string => {
    return text.replace(/^\//, '').replace(/\/$/, '');
 };
 
-export const isValidProxyUrl = (url: string) => url.match(/^https?:\/\/[^:\/]+(:\d+)?(\/.*)?$/) !== null;
+// export const isValidProxyUrl = (url: string) => url.match(/^https?:\/\/[^:\/]+(:\d+)?(\/.*)?$/) !== null;
+/**
+ * Returns true if `url` is a well-formed HTTP or HTTPS URL.
+ */
+export function isValidProxyUrl(url: string): boolean {
+   try {
+      const parsed = new URL(url);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+   } catch {
+      return false;
+   }
+}
 
 export const executeAngularCli = async (command: ISupportedAngularCommand, ...options: string[]) => {
    await new Promise<void>((resolveFun, rejectFun) => {

--- a/m3-odin/package-lock.json
+++ b/m3-odin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "m3-odin-samples",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "m3-odin-samples",
-      "version": "7.1.1",
+      "version": "7.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@angular/animations": "^18.2.4",

--- a/m3-odin/package.json
+++ b/m3-odin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "m3-odin-samples",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",

--- a/m3-odin/projects/infor-up/m3-odin-angular/package.json
+++ b/m3-odin/projects/infor-up/m3-odin-angular/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@infor-up/m3-odin-angular",
    "private": false,
-   "version": "7.1.1",
+   "version": "7.2.0",
    "description": "Odin Angular for M3 web application development.",
    "author": {
       "name": "William Hernebrink",
@@ -18,7 +18,7 @@
    "peerDependencies": {
       "@angular/common": "^18.2.4",
       "@angular/core": "^18.2.4",
-      "@infor-up/m3-odin": "7.1.1",
+      "@infor-up/m3-odin": "7.2.0",
       "rxjs": "^7.8.0"
    }
 }

--- a/m3-odin/projects/infor-up/m3-odin-angular/package.json
+++ b/m3-odin/projects/infor-up/m3-odin-angular/package.json
@@ -4,8 +4,8 @@
    "version": "7.1.1",
    "description": "Odin Angular for M3 web application development.",
    "author": {
-      "name": "Fredrik Eriksson",
-      "email": "fredrik.eriksson@infor.com"
+      "name": "William Hernebrink",
+      "email": "william.hernebrink@infor.com"
    },
    "license": "Apache-2.0",
    "repository": {

--- a/m3-odin/projects/infor-up/m3-odin/package.json
+++ b/m3-odin/projects/infor-up/m3-odin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@infor-up/m3-odin",
   "private": false,
-  "version": "7.1.1",
+  "version": "7.2.0",
   "description": "Odin for M3 web application development.",
   "author": {
     "name": "William Hernebrink",

--- a/m3-odin/projects/infor-up/m3-odin/package.json
+++ b/m3-odin/projects/infor-up/m3-odin/package.json
@@ -4,8 +4,8 @@
   "version": "7.1.1",
   "description": "Odin for M3 web application development.",
   "author": {
-    "name": "Fredrik Eriksson",
-    "email": "fredrik.eriksson@infor.com"
+    "name": "William Hernebrink",
+    "email": "william.hernebrink@infor.com"
   },
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Adding a separate `login-cloud` command to odin cli. This will enable `odin serve --multi-tenant`.

- To use the new `login-cloud` command in an existing project, you need to update your `odin.json` file to include the following properties (update with your own urls):
  ```json
  {
    ...
    "m3Url": "https://m3xyz.m3.xyz.inforcloudsuite.com",
    "portalUrl": "https://mingle-xyz-portal.xyz.inforcloudsuite.com"
  }
  ```